### PR TITLE
fix: resolve flutter analyze errors and warnings for v1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - 2025-07-19
+
+### Fixed
+- 🐛 Fixed critical type errors in configuration factory constructor
+- 🔧 Removed deprecated lint rules (invariant_booleans, iterable_contains_unrelated_type, list_remove_unrelated_type, prefer_equal_for_default_values)
+- 📝 Fixed dangling library doc comments by adding proper library declaration
+- 🧪 Cleaned up test files: removed unused imports and variables, fixed unnecessary null assertions
+- ✅ Resolved all flutter analyze errors and warnings
+
+### Improved
+- 🎯 Enhanced type safety with proper type casting in configuration parsing
+- 📋 Better code quality compliance with latest Dart analysis rules
+- 🧹 Cleaner test code without unused dependencies
+
 ## [1.0.2] - 2025-07-06
 
 ### Changed

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -65,13 +65,10 @@ linter:
     flutter_style_todos: true
     hash_and_equals: true
     implementation_imports: true
-    invariant_booleans: true
-    iterable_contains_unrelated_type: true
     join_return_with_assignment: true
     leading_newlines_in_multiline_strings: true
     library_names: true
     library_prefixes: true
-    list_remove_unrelated_type: true
     literal_only_boolean_expressions: true
     missing_whitespace_between_adjacent_strings: true
     no_adjacent_strings_in_list: true
@@ -90,7 +87,6 @@ linter:
     prefer_collection_literals: true
     prefer_conditional_assignment: true
     prefer_contains: true
-    prefer_equal_for_default_values: true
     prefer_final_fields: true
     prefer_final_in_for_each: true
     prefer_final_locals: true

--- a/lib/iconfont.dart
+++ b/lib/iconfont.dart
@@ -6,6 +6,7 @@
 ///
 /// Or for watch mode:
 /// dart run build_runner watch
+library flutter_iconfont_generator;
 
 // This file intentionally left mostly empty
 // The actual generation is handled by the builder

--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -89,7 +89,7 @@ class IconFontConfig {
   /// ```dart
   /// // Uses default size (18)
   /// IconFont(IconNames.home)
-  /// 
+  ///
   /// // Override with custom size
   /// IconFont(IconNames.home, size: 24)
   /// ```
@@ -157,11 +157,11 @@ class IconFontConfig {
   /// ```
   factory IconFontConfig.fromMap(Map<String, dynamic> map) {
     return IconFontConfig(
-      symbolUrl: map['symbol_url'] ?? '',
-      saveDir: map['save_dir'] ?? './lib/iconfont',
-      trimIconPrefix: map['trim_icon_prefix'] ?? 'icon',
-      defaultIconSize: map['default_icon_size'] ?? 18,
-      nullSafety: map['null_safety'] ?? true,
+      symbolUrl: (map['symbol_url'] as String?) ?? '',
+      saveDir: (map['save_dir'] as String?) ?? './lib/iconfont',
+      trimIconPrefix: (map['trim_icon_prefix'] as String?) ?? 'icon',
+      defaultIconSize: (map['default_icon_size'] as int?) ?? 18,
+      nullSafety: (map['null_safety'] as bool?) ?? true,
     );
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -198,6 +198,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_lints:
+    dependency: "direct dev"
+    description:
+      name: flutter_lints
+      sha256: "3f41d009ba7172d5ff9be5f6e6e6abb4300e263aab8866d2a0842ed2a70f8f0c"
+      url: "https://pub.flutter-io.cn"
+    source: hosted
+    version: "4.0.0"
   flutter_svg:
     dependency: "direct main"
     description:
@@ -307,6 +315,14 @@ packages:
       url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.0.1"
+  lints:
+    dependency: transitive
+    description:
+      name: lints
+      sha256: "976c774dd944a42e83e2467f4cc670daef7eed6295b10b36ae8c85bcbf828235"
+      url: "https://pub.flutter-io.cn"
+    source: hosted
+    version: "4.0.0"
   logging:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/suyulin/flutter_iconfont_generator
 issue_tracker: https://github.com/suyulin/flutter_iconfont_generator/issues
 documentation: https://github.com/suyulin/flutter_iconfont_generator/blob/main/README.md
 
-version: 1.0.2
+version: 1.0.3
 
 # Platform support declarations
 platforms:

--- a/test/fetcher_test.dart
+++ b/test/fetcher_test.dart
@@ -1,26 +1,12 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:flutter_iconfont_generator/src/fetcher.dart';
-import 'package:http/http.dart' as http;
-import 'package:http/testing.dart';
 
 void main() {
   group('IconFontFetcher', () {
     test('should fetch SVG content from HTTP URL', () async {
-      final mockClient = MockClient((request) async {
-        expect(request.url.toString(), 
-               equals('https://at.alicdn.com/t/font_123.js'));
-        
-        const jsContent = '''
-        !function(){ var svg = '<svg><symbol id="icon-home"><path d="M512 85L938 512"></path></symbol></svg>'; }();
-        ''';
-        
-        return http.Response(jsContent, 200);
-      });
-
       // Note: This is a simplified test as we can't easily mock the HTTP client
       // without dependency injection. In a real implementation, we'd want to
       // make the HTTP client injectable for testing.
-      
+
       // For now, let's test the URL processing logic
       expect(() async {
         // This would need actual network access or mocked HTTP client
@@ -31,25 +17,25 @@ void main() {
     test('should convert protocol-relative URL to HTTPS', () {
       // Test URL processing logic
       const symbolUrl = '//at.alicdn.com/t/font_123.js';
-      
+
       // Since the method is static and makes HTTP calls, we'll test the logic
       // by examining what the expected behavior should be
       expect(symbolUrl.startsWith('//'), isTrue);
-      
+
       final expectedUrl = 'https:$symbolUrl';
       expect(expectedUrl, equals('https://at.alicdn.com/t/font_123.js'));
     });
 
     test('should convert symbol URL to JS URL', () {
       const symbolUrl = 'https://at.alicdn.com/t/font_123.symbol';
-      
+
       final expectedUrl = symbolUrl.replaceAll('symbol', 'js');
       expect(expectedUrl, equals('https://at.alicdn.com/t/font_123.js'));
     });
 
     test('should handle already valid HTTP URL', () {
       const symbolUrl = 'https://at.alicdn.com/t/font_123.js';
-      
+
       // URL should remain unchanged if it's already HTTP/HTTPS
       expect(symbolUrl.startsWith('http'), isTrue);
     });
@@ -70,9 +56,9 @@ void main() {
       }();
       ''';
 
-      final svgMatch = RegExp(r'<svg[^>]*>(.*?)</svg>', dotAll: true)
-          .firstMatch(jsContent);
-      
+      final svgMatch =
+          RegExp(r'<svg[^>]*>(.*?)</svg>', dotAll: true).firstMatch(jsContent);
+
       expect(svgMatch, isNotNull);
       expect(svgMatch!.group(1), contains('symbol id="icon-home"'));
     });
@@ -82,12 +68,12 @@ void main() {
       var svg = '<svg viewBox="0 0 1024 1024"><symbol id="icon-user"><path d="M512 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z" fill="#000"></path></symbol><symbol id="icon-settings"><circle cx="12" cy="12" r="3"></circle></symbol></svg>';
       ''';
 
-      final svgMatch = RegExp(r'<svg[^>]*>(.*?)</svg>', dotAll: true)
-          .firstMatch(jsContent);
-      
+      final svgMatch =
+          RegExp(r'<svg[^>]*>(.*?)</svg>', dotAll: true).firstMatch(jsContent);
+
       expect(svgMatch, isNotNull);
-      expect(svgMatch!.group(1), contains('symbol id="icon-user"'));
-      expect(svgMatch!.group(1), contains('symbol id="icon-settings"'));
+      expect(svgMatch?.group(1), contains('symbol id="icon-user"'));
+      expect(svgMatch?.group(1), contains('symbol id="icon-settings"'));
     });
 
     test('should detect missing SVG content', () {
@@ -97,18 +83,18 @@ void main() {
       }();
       ''';
 
-      final svgMatch = RegExp(r'<svg[^>]*>(.*?)</svg>', dotAll: true)
-          .firstMatch(jsContent);
-      
+      final svgMatch =
+          RegExp(r'<svg[^>]*>(.*?)</svg>', dotAll: true).firstMatch(jsContent);
+
       expect(svgMatch, isNull);
     });
 
     test('should handle empty JS response', () {
       const jsContent = '';
 
-      final svgMatch = RegExp(r'<svg[^>]*>(.*?)</svg>', dotAll: true)
-          .firstMatch(jsContent);
-      
+      final svgMatch =
+          RegExp(r'<svg[^>]*>(.*?)</svg>', dotAll: true).firstMatch(jsContent);
+
       expect(svgMatch, isNull);
     });
 
@@ -117,9 +103,9 @@ void main() {
       var svg = '<svg><symbol id="broken-svg"<path d="invalid">';
       ''';
 
-      final svgMatch = RegExp(r'<svg[^>]*>(.*?)</svg>', dotAll: true)
-          .firstMatch(jsContent);
-      
+      final svgMatch =
+          RegExp(r'<svg[^>]*>(.*?)</svg>', dotAll: true).firstMatch(jsContent);
+
       expect(svgMatch, isNull);
     });
 
@@ -162,9 +148,11 @@ void main() {
 
     group('SVG content extraction', () {
       test('should create proper SVG wrapper', () {
-        const innerContent = '<symbol id="test"><path d="M0 0"></path></symbol>';
-        const expectedSvg = '<svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg">$innerContent</svg>';
-        
+        const innerContent =
+            '<symbol id="test"><path d="M0 0"></path></symbol>';
+        const expectedSvg =
+            '<svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg">$innerContent</svg>';
+
         expect(expectedSvg, contains('viewBox="0 0 1024 1024"'));
         expect(expectedSvg, contains('xmlns="http://www.w3.org/2000/svg"'));
         expect(expectedSvg, contains(innerContent));

--- a/test/library_test.dart
+++ b/test/library_test.dart
@@ -79,7 +79,8 @@ void main() {
                 d: 'M512 85.333333L938.666667 512H853.333333V896H597.333333V640H426.666667V896H170.666667V512H85.333333L512 85.333333Z',
                 fill: '#000000',
                 attributes: {
-                  'd': 'M512 85.333333L938.666667 512H853.333333V896H597.333333V640H426.666667V896H170.666667V512H85.333333L512 85.333333Z',
+                  'd':
+                      'M512 85.333333L938.666667 512H853.333333V896H597.333333V640H426.666667V896H170.666667V512H85.333333L512 85.333333Z',
                   'fill': '#000000',
                 },
               ),
@@ -92,7 +93,8 @@ void main() {
               SvgPath(
                 d: 'M512 512c123.712 0 224-100.288 224-224S635.712 64 512 64 288 164.288 288 288s100.288 224 224 224z m0 128c-149.504 0-448 74.752-448 224v96h896v-96c0-149.248-298.496-224-448-224z',
                 attributes: {
-                  'd': 'M512 512c123.712 0 224-100.288 224-224S635.712 64 512 64 288 164.288 288 288s100.288 224 224 224z m0 128c-149.504 0-448 74.752-448 224v96h896v-96c0-149.248-298.496-224-448-224z',
+                  'd':
+                      'M512 512c123.712 0 224-100.288 224-224S635.712 64 512 64 288 164.288 288 288s100.288 224 224 224z m0 128c-149.504 0-448 74.752-448 224v96h896v-96c0-149.248-298.496-224-448-224z',
                 },
               ),
             ],
@@ -157,17 +159,18 @@ void main() {
         // This test verifies the export is available without actually running the builder
         expect(() {
           // This would be used in a real build.yaml configuration
-          const builderConfig = {
-            'builders': {
-              'flutter_iconfont_generator|iconfont_builder': {
-                'import': 'package:flutter_iconfont_generator/builder.dart',
-                'builder_factories': ['iconFontBuilder'],
-                'build_extensions': {'.yaml': ['.dart']},
-                'auto_apply': 'dependents',
-                'build_to': 'source',
-              }
-            }
-          };
+          // Configuration example is commented out as it's not actually used
+          // {
+          //   'builders': {
+          //     'flutter_iconfont_generator|iconfont_builder': {
+          //       'import': 'package:flutter_iconfont_generator/builder.dart',
+          //       'builder_factories': ['iconFontBuilder'],
+          //       'build_extensions': {'.yaml': ['.dart']},
+          //       'auto_apply': 'dependents',
+          //       'build_to': 'source',
+          //     }
+          //   }
+          // };
         }, returnsNormally);
       });
     });
@@ -234,7 +237,7 @@ void main() {
 
         final symbols = SvgParser.parseSymbols(complexSvg);
         expect(symbols, hasLength(1));
-        
+
         final symbol = symbols.first;
         expect(symbol.paths, hasLength(2));
         expect(symbol.paths[0].attributes['stroke'], equals('#000000'));


### PR DESCRIPTION
- Fix critical type errors in configuration factory constructor
- Remove deprecated lint rules (invariant_booleans, iterable_contains_unrelated_type, etc.)
- Fix dangling library doc comments with proper library declaration
- Clean up test files: remove unused imports and variables
- Fix unnecessary null assertions in tests
- Enhance type safety with proper type casting
- Improve code quality compliance with latest Dart analysis rules

All flutter analyze errors and warnings have been resolved.